### PR TITLE
chore: update entities and refacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,22 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "cookie-parser": "^1.4.6",
+        "cookie-parser": "1.4.6",
         "dotenv": "16.0.3",
         "express": "4.18.2",
         "jsonwebtoken": "9.0.0",
         "mongoose": "7.0.0",
-        "multer": "^1.4.5-lts.1",
-        "redis": "^4.6.5",
-        "ws": "^8.12.1"
+        "multer": "1.4.5-lts.1",
+        "redis": "4.6.5",
+        "ws": "8.12.1"
       },
       "devDependencies": {
-        "@types/cookie-parser": "^1.4.3",
+        "@types/cookie-parser": "1.4.3",
         "@types/express": "4.17.17",
         "@types/jsonwebtoken": "9.0.1",
-        "@types/multer": "^1.4.7",
+        "@types/multer": "1.4.7",
         "@types/node": "18.14.4",
-        "@types/redis": "^4.0.11",
-        "@types/ws": "^8.5.4",
+        "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.54.0",
         "@typescript-eslint/parser": "5.54.0",
         "eslint": "8.35.0",
@@ -33,7 +32,7 @@
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.8.4",
         "ts-node": "10.9.1",
-        "tsc-watch": "^6.0.0",
+        "tsc-watch": "6.0.0",
         "typescript": "4.9.5"
       }
     },
@@ -438,16 +437,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/redis": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.11.tgz",
-      "integrity": "sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==",
-      "deprecated": "This is a stub types definition. redis provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "redis": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/jsonwebtoken": "9.0.1",
     "@types/multer": "1.4.7",
     "@types/node": "18.14.4",
-    "@types/redis": "4.0.11",
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { env } from 'node:process';
 require('dotenv').config();
 
-const port: number = +env.PORT;
+const port: number = +env.PORT ?? 5000;
 export function App(): void {
   const app: express.Application = express();
 

--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -11,7 +11,12 @@ export async function connectToMongoDB(): Promise<void> {
   set('strictQuery', false);
 
   await db
-    .connect(`mongodb://${mongoUser}:${mongoPassword}@mongo-rpg:${mongoPort}`)
+    .connect(`mongodb://${mongoUser}:${mongoPassword}@mongo-rpg:${mongoPort}`, {
+      // authSource: 'admin',
+      // directConnection: true,
+      // retryWrites: true,
+      // writeConcern: 'majority' as WriteConcern,
+    })
     .then(() => console.log('\x1b[33;1m', '-----> Conectado ao MongoDB <-----', '\x1b[0m\n'))
     .catch((err: MongooseError) => console.log(err));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
 import { App } from './config/app';
 
-const app = App();
-
-const PORT = parseInt(process.env.PORT || '5000');
-
-app.listen(PORT);
+App();

--- a/src/modules/feedMessageComments/interface.ts
+++ b/src/modules/feedMessageComments/interface.ts
@@ -1,9 +1,8 @@
-import { FeedMessagesModel } from '../feedMessages/interface';
-import { IUser } from '../users/interface';
+import { Types } from 'mongoose';
 
 export interface FeedMessageCommentsModel {
-  feedMessage: FeedMessagesModel;
-  author: IUser;
+  feedMessage: Types.ObjectId;
+  author: Types.ObjectId;
   content: string;
   createdAt: Date;
   updatedAt: Date | undefined;

--- a/src/modules/feedMessageComments/model.ts
+++ b/src/modules/feedMessageComments/model.ts
@@ -1,14 +1,13 @@
-import mongoose, { Schema, SchemaTypeOptions, now } from 'mongoose';
+import { Schema, SchemaTypeOptions, model, now } from 'mongoose';
 import { FeedMessageCommentsModel } from './interface';
-require('dotenv').config();
 
-const FeedMessageCommentsSchema = new mongoose.Schema<SchemaTypeOptions<FeedMessageCommentsModel>>({
-  feedMessage: { type: Schema.Types.ObjectId, required: true },
-  author: { type: Schema.Types.ObjectId, required: true },
+const FeedMessageCommentsSchema = new Schema<SchemaTypeOptions<FeedMessageCommentsModel>>({
+  feedMessage: { type: Schema.Types.ObjectId, required: true, ref: 'FeedMessage' },
+  author: { type: Schema.Types.ObjectId, required: true, ref: 'Author' },
   content: { type: String },
-  createdAt: { type: Date, default: now },
+  createdAt: { type: Date, default: now, immutable: true },
   updatedAt: { type: Date, default: null },
   deletedAt: { type: Date, default: null },
 });
 
-export const FeedMessagesComments = mongoose.model('FeedMessageComments', FeedMessageCommentsSchema);
+export const FeedMessagesComments = model('FeedMessageComments', FeedMessageCommentsSchema);

--- a/src/modules/feedMessages/interface.ts
+++ b/src/modules/feedMessages/interface.ts
@@ -1,8 +1,9 @@
-import { IUser, PlayerCharacters } from '../users/interface';
+import { Types } from 'mongoose';
+import { PlayerCharacters } from '../users/interface';
 
 export interface FeedMessagesModel {
   feedRoom: any /* FeedRoomsModel */;
-  owner: IUser;
+  owner: Types.ObjectId;
   title: string;
   content: string;
   image: string;

--- a/src/modules/feedMessages/model.ts
+++ b/src/modules/feedMessages/model.ts
@@ -1,26 +1,25 @@
-import mongoose, { Schema, SchemaTypeOptions, now } from 'mongoose';
+import { Schema, SchemaTypeOptions, model, now } from 'mongoose';
 import { FeedMessagesModel } from './interface';
-require('dotenv').config();
 
-const FeedMessagesSchema = new mongoose.Schema<SchemaTypeOptions<FeedMessagesModel>>({
-  feedRoom: { type: Schema.Types.ObjectId, required: true },
-  owner: { type: Schema.Types.ObjectId, required: true },
+const FeedMessagesSchema = new Schema<SchemaTypeOptions<FeedMessagesModel>>({
+  feedRoom: { type: Schema.Types.ObjectId, required: true, ref: 'FeedRoom' },
+  owner: { type: Schema.Types.ObjectId, required: true, ref: 'Owner' },
   title: { type: String },
   content: { type: String },
   image: { type: String },
   numberOfPlayers: { type: Number },
   playerCharacters: [
     {
-      characterId: { type: Number },
+      characterId: { type: [Number], index: { sparse: true } },
       characterName: { type: String },
-      player: { type: Schema.Types.ObjectId },
+      player: { type: Schema.Types.ObjectId, ref: 'Player' },
     },
   ],
   numberOfComments: { type: Number },
   numberOfLikes: { type: Number },
-  createdAt: { type: Date, default: now },
-  updatedAt: { type: Date },
-  deletedAt: { type: Date },
+  createdAt: { type: Date, default: now, immutable: true },
+  updatedAt: { type: Date, default: null },
+  deletedAt: { type: Date, default: null },
 });
 
-export const FeedMessages = mongoose.model('FeedMessages', FeedMessagesSchema);
+export const FeedMessages = model('FeedMessages', FeedMessagesSchema);

--- a/src/modules/users/interface.ts
+++ b/src/modules/users/interface.ts
@@ -1,3 +1,5 @@
+import { Types } from 'mongoose';
+
 export interface IUser {
   email: string;
   password: string;
@@ -20,6 +22,6 @@ export interface ILoginUser {
 export interface PlayerCharacters {
   characterId: number;
   characterName: string;
-  player: IUser | undefined;
+  player: Types.ObjectId | undefined;
   deletedAt?: Date | undefined;
 }


### PR DESCRIPTION
- retirei a lib `@types/redis`, pois o próprio Redis já possui sua tipagem própria. 
- Fiz refact em algumas partes, e adicionei umas opções específicas.

Quando forem referenciar outra tabela, pode fazer a citação da interface para o schema:

```graphql
interface UniModel {
  name: string
  mentions: Types.ObjectId
}

... 
Schema<SchemaTypeOptions<UniModel>>({
  titles: { type: Schema.Types.ObjectId, ref: 'Titles' }
})